### PR TITLE
Handler for bytes type

### DIFF
--- a/hrepr/__init__.py
+++ b/hrepr/__init__.py
@@ -413,6 +413,9 @@ def handler_bool(obj, H, hrepr):
     else:
         return H.span['hrepr-False', 'hrepr-bool']("False")
 
+def handler_bytes(obj, H, hrepr):
+    return hrepr.stdrepr(obj.hex(), cls='hrepr-bytes')
+
 def handler_Tag(obj, H, hrepr):
     """
     Returns the default representation for a tag, which is the tag itself.
@@ -474,6 +477,7 @@ class StdHRepr(HRepr):
             frozenset: handler_frozenset,
             dict: handler_dict,
             bool: handler_bool,
+            bytes: handler_bytes,
             Tag: handler_Tag
         }
 
@@ -482,6 +486,7 @@ class StdHRepr(HRepr):
             int: handler_scalar,
             float: handler_scalar,
             str: handler_short_str,
+            bytes: handler_short_str,
             list: handler_short_list,
             tuple: handler_short_tuple,
             set: handler_short_set,

--- a/hrepr/style/hrepr.css
+++ b/hrepr/style/hrepr.css
@@ -34,6 +34,24 @@
 	color: #888;
 }
 
+.hrepr-bytes {
+	color: #666;
+	font-family: monospace;
+	white-space: pre;
+}
+
+.hrepr-bytes:before {
+	content: "bytes.fromhex(“";
+	font-family: normal;
+	color: #888;
+}
+
+.hrepr-bytes:after {
+	content: "”)";
+	font-family: normal;
+	color: #888;
+}
+
 .hrepr-True {
 	color: green;
 }


### PR DESCRIPTION
This patch adds a handler for the `bytes` type.  It looks like this (see `"nonce"` item):

![a dict having a bytes value](https://user-images.githubusercontent.com/12431/47355279-f1ffab00-d6fb-11e8-8bed-7ef74fc0ce25.png)
