### PR TITLE
Fix UnicodeDecodeError on non-UTF-8 environments

### DIFF
--- a/hrepr/h.py
+++ b/hrepr/h.py
@@ -6,8 +6,8 @@ from html import escape
 
 # CSS for hrepr
 styledir = f'{os.path.dirname(__file__)}/style'
-css_nbreset = open(f'{styledir}/nbreset.css').read()
-css_hrepr = open(f'{styledir}/hrepr.css').read()
+css_nbreset = open(f'{styledir}/nbreset.css', encoding='utf-8').read()
+css_hrepr = open(f'{styledir}/hrepr.css', encoding='utf-8').read()
 
 
 # These tags are self-closing and cannot have children.


### PR DESCRIPTION
This patch fixes `UnicodeDecodeError` thrown at import time on non-UTF-8 environments (such as non-English Windows).